### PR TITLE
Switch to a fork of jsch (com.github.mwiede) and upgrade to 0.2.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/jsch/target/

--- a/jsch/pom.xml
+++ b/jsch/pom.xml
@@ -29,12 +29,12 @@
 
     <groupId>org.glassfish.external</groupId>
     <artifactId>jsch</artifactId>
-    <version>0.1.65-SNAPSHOT</version>
+    <version>0.2.9-SNAPSHOT</version>
 
     <name>jsch repackaged as an OSGI bundle</name>
 
     <properties>
-        <jsch.version>0.1.65</jsch.version>
+        <jsch.version>0.2.9</jsch.version>
         <release.arguments />
     </properties>
 
@@ -139,8 +139,8 @@
                              in the final bundle
                         -->
                         <!-- Exclude unnecessary imports -->
-                        <Export-Package>*;version=${jsch.version}</Export-Package>
-                        <Import-Package>!com.jcraft.jzlib,*</Import-Package>
+                        <Export-Package>com.jcraft.jsch;-noimport:=true</Export-Package>
+                        <Import-Package>!com.jcraft.jzlib,*;resolution:=optional</Import-Package>
                         <Private-Package>!*</Private-Package>
                     </instructions>
                     <!-- Maven uses the output directory (target/classes)

--- a/jsch/pom.xml
+++ b/jsch/pom.xml
@@ -29,12 +29,12 @@
 
     <groupId>org.glassfish.external</groupId>
     <artifactId>jsch</artifactId>
-    <version>0.1.57-SNAPSHOT</version>
+    <version>0.1.65-SNAPSHOT</version>
 
     <name>jsch repackaged as an OSGI bundle</name>
 
     <properties>
-        <jsch.version>0.1.54</jsch.version>
+        <jsch.version>0.1.65</jsch.version>
         <release.arguments />
     </properties>
 
@@ -79,7 +79,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>5.1.8</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -179,7 +179,7 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>com.jcraft</groupId>
+                                    <groupId>com.github.mwiede</groupId>
                                     <artifactId>jsch</artifactId>
                                     <version>${jsch.version}</version>
                                     <classifier>sources</classifier>
@@ -257,7 +257,7 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>com.jcraft</groupId>
+            <groupId>com.github.mwiede</groupId>
             <artifactId>jsch</artifactId>
             <version>${jsch.version}</version>
             <optional>true</optional>


### PR DESCRIPTION
The version 0.2.9 brings some optional dependencies. They aren't needed in GlassFish:
 * 0.1.66 brings in dependency on jna, which needs to be added into the bundle too
 * 0.2.0 bring dependencies on slf4j and log4j, which are optional

This version fixes a defect when creating an SSH node with a private key instead of password.