### PR TITLE
Released Derby+Ant, updated howto

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,28 @@
 # repackaged
 Copies of third party open source projects that are used in the build of GlassFish, along with tools to build those projects. GlassFish depends on the versions of these projects that we build, not directly on binaries produced by the originating project.
 
+# How to Release Ant
+
+1. Check the derby.version in the POM. Don't override it on command line, it must be same as the redeployed artifact version - or a snapshot. Copy the derby.version to the bash property, see the example.
+
+2. Example:
+```
+version=1.10.15
+git checkout -b release
+cd ant
+mvn release:prepare -DpushChanges=false -DdevelopmentVersion=1.10.16-SNAPSHOT -DreleaseVersion=${version} -Dtag=Ant-${version} -Dresume=false
+git push eclipse Ant-${version}
+```
+
+3. Visit Eclipse CI and run the deployment for Derby and the tag: https://ci.eclipse.org/glassfish/view/Release/job/repackaged-deploy
+4. Visit Maven Central Deployments: https://central.sonatype.com/publishing/deployments
+5. Manually check that everything is as expected for the last time and press Drop or Publish.
+6. Wait until the package is distributed to the Maven Central. Not that UI indexes are updated with large latency, but artifacts will be available sooner.
+7. Finally push the branch and create a PR to master
+```
+git push eclipse release
+```
+
 # How to Release Derby
 
 1. Check the derby.version in the POM. Don't override it on command line, it must be same as the redeployed artifact version - or a snapshot. Copy the derby.version to the bash property, see the example.
@@ -9,6 +31,7 @@ Copies of third party open source projects that are used in the build of GlassFi
 ```
 version=10.17.1.0
 git checkout -b release
+cd derby
 mvn release:prepare -DpushChanges=false -DdevelopmentVersion=10.17.1.0-SNAPSHOT -DreleaseVersion=${version} -Dtag=Derby-${version} -Dresume=false
 git push eclipse Derby-${version}
 ```
@@ -19,5 +42,7 @@ git push eclipse Derby-${version}
 6. Wait until the package is distributed to Maven Central. Not that UI indexes are updated with large latency, but artifacts will be available sooner.
 7. Finally push th branch and create a PR to master
 ```
-git push eclipse release_derby
+git push eclipse release
 ```
+
+Same can be applied to other subprojects.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # repackaged
 Copies of third party open source projects that are used in the build of GlassFish, along with tools to build those projects. GlassFish depends on the versions of these projects that we build, not directly on binaries produced by the originating project.
+
+# How to Release Derby
+
+1. Check the derby.version in the POM. Don't override it on command line, it must be same as the redeployed artifact version - or a snapshot. Copy the derby.version to the bash property, see the example.
+
+2. Example:
+```
+version=10.17.1.0
+git checkout -b release
+mvn release:prepare -DpushChanges=false -DdevelopmentVersion=10.17.1.0-SNAPSHOT -DreleaseVersion=${version} -Dtag=Derby-${version} -Dresume=false
+git push eclipse Derby-${version}
+```
+
+3. Visit Eclipse CI and run the deployment for Derby and the tag: https://ci.eclipse.org/glassfish/view/Release/job/repackaged-deploy
+4. Visit Maven Central Deployments: https://central.sonatype.com/publishing/deployments
+5. Manually check that everything is as expected for the last time and press Drop or publish.
+6. Wait until the package is distributed to Maven Central. Not that UI indexes are updated with large latency, but artifacts will be available sooner.
+7. Finally push th branch and create a PR to master
+```
+git push eclipse release_derby
+```

--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -17,9 +17,7 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
@@ -30,7 +28,7 @@
 
     <groupId>org.glassfish.external</groupId>
     <artifactId>ant</artifactId>
-    <version>1.10.15-SNAPSHOT</version>
+    <version>1.10.15</version>
 
     <name>Ant OSGi</name>
     <description>Apache Ant repackaged for Eclipse GlassFish to support OSGi</description>
@@ -57,7 +55,7 @@
         <connection>scm:git:git@github.com:eclipse-ee4j/glassfish-repackaged.git</connection>
         <developerConnection>scm:git:git@github.com:eclipse-ee4j/glassfish-repackaged.git</developerConnection>
         <url>https://github.com/eclipse-ee4j/glassfish-repackaged.git</url>
-        <tag>HEAD</tag>
+        <tag>Ant-1.10.15</tag>
     </scm>
 
     <issueManagement>

--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>org.glassfish.external</groupId>
     <artifactId>ant</artifactId>
-    <version>1.10.15</version>
+    <version>1.10.16-SNAPSHOT</version>
 
     <name>Ant OSGi</name>
     <description>Apache Ant repackaged for Eclipse GlassFish to support OSGi</description>
@@ -55,7 +55,7 @@
         <connection>scm:git:git@github.com:eclipse-ee4j/glassfish-repackaged.git</connection>
         <developerConnection>scm:git:git@github.com:eclipse-ee4j/glassfish-repackaged.git</developerConnection>
         <url>https://github.com/eclipse-ee4j/glassfish-repackaged.git</url>
-        <tag>Ant-1.10.15</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <issueManagement>

--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -139,6 +139,11 @@
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.12.0</version>
+                    <configuration>
+                        <notimestamp>true</notimestamp>
+                        <splitindex>true</splitindex>
+                        <doclint>none</doclint>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -296,10 +301,10 @@
                 <executions>
                     <execution>
                         <id>add-sources</id>
-                        <phase>process-sources</phase>
                         <goals>
                             <goal>add-source</goal>
                         </goals>
+                        <phase>process-sources</phase>
                         <configuration>
                             <sources>
                                 <source>${project.build.directory}/sources</source>
@@ -309,14 +314,37 @@
                 </executions>
             </plugin>
             <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-gpg-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
-                        <phase>deploy</phase>
                         <goals>
                             <goal>sign</goal>
                         </goals>
+                        <phase>deploy</phase>
                     </execution>
                 </executions>
             </plugin>

--- a/derby/pom.xml
+++ b/derby/pom.xml
@@ -17,9 +17,7 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
@@ -30,7 +28,7 @@
 
     <groupId>org.glassfish.external</groupId>
     <artifactId>derby</artifactId>
-    <version>10.17.1.0-SNAPSHOT</version>
+    <version>10.16.1.1</version>
     <packaging>pom</packaging>
 
     <name>Apache Derby for Eclipse GlassFish</name>
@@ -58,7 +56,7 @@
         <connection>scm:git:git@github.com:eclipse-ee4j/glassfish-repackaged.git</connection>
         <developerConnection>scm:git:git@github.com:eclipse-ee4j/glassfish-repackaged.git</developerConnection>
         <url>https://github.com/eclipse-ee4j/glassfish-repackaged.git</url>
-        <tag>HEAD</tag>
+        <tag>Derby-10.16.1.1</tag>
     </scm>
 
     <issueManagement>

--- a/derby/pom.xml
+++ b/derby/pom.xml
@@ -91,7 +91,7 @@
     </distributionManagement>
 
     <properties>
-        <derby.version>10.16.1.1</derby.version>
+        <derby.version>10.17.1.0</derby.version>
         <derby.download.url>https://dlcdn.apache.org//db/derby/db-derby-${derby.version}/db-derby-${derby.version}-bin.zip</derby.download.url>
     </properties>
 

--- a/derby/pom.xml
+++ b/derby/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>org.glassfish.external</groupId>
     <artifactId>derby</artifactId>
-    <version>10.16.1.1</version>
+    <version>10.17.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Apache Derby for Eclipse GlassFish</name>
@@ -56,7 +56,7 @@
         <connection>scm:git:git@github.com:eclipse-ee4j/glassfish-repackaged.git</connection>
         <developerConnection>scm:git:git@github.com:eclipse-ee4j/glassfish-repackaged.git</developerConnection>
         <url>https://github.com/eclipse-ee4j/glassfish-repackaged.git</url>
-        <tag>Derby-10.16.1.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <issueManagement>

--- a/derby/pom.xml
+++ b/derby/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>org.glassfish.external</groupId>
     <artifactId>derby</artifactId>
-    <version>10.17.1.0</version>
+    <version>10.17.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Apache Derby for Eclipse GlassFish</name>
@@ -56,7 +56,7 @@
         <connection>scm:git:git@github.com:eclipse-ee4j/glassfish-repackaged.git</connection>
         <developerConnection>scm:git:git@github.com:eclipse-ee4j/glassfish-repackaged.git</developerConnection>
         <url>https://github.com/eclipse-ee4j/glassfish-repackaged.git</url>
-        <tag>Derby-10.17.1.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <issueManagement>

--- a/derby/pom.xml
+++ b/derby/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>org.glassfish.external</groupId>
     <artifactId>derby</artifactId>
-    <version>10.17.1.0-SNAPSHOT</version>
+    <version>10.17.1.0</version>
     <packaging>pom</packaging>
 
     <name>Apache Derby for Eclipse GlassFish</name>
@@ -56,7 +56,7 @@
         <connection>scm:git:git@github.com:eclipse-ee4j/glassfish-repackaged.git</connection>
         <developerConnection>scm:git:git@github.com:eclipse-ee4j/glassfish-repackaged.git</developerConnection>
         <url>https://github.com/eclipse-ee4j/glassfish-repackaged.git</url>
-        <tag>HEAD</tag>
+        <tag>Derby-10.17.1.0</tag>
     </scm>
 
     <issueManagement>


### PR DESCRIPTION
Ant and Derby were released to Maven Central.
I will create another PR for Antlr dependencies when I resolve the whole problem with Antlr2->4 migration.